### PR TITLE
Add lazy loading to the art page.

### DIFF
--- a/art.html
+++ b/art.html
@@ -82,38 +82,38 @@
                 </div>
 
                 <div class="gallery-grid">
-                    <img src="/Images/Art/gun.png" >
-                    <img src="/Images/Art/0000fenrefsheet.png" >
-                    <img src="/Images/Art/babbledog.png" >
-                    <img src="/Images/Art/gmmishark.webp" >
-                    <img src="/Images/Art/biggreedy.webp" >
-                    <img src="/Images/Art/glas.webp" >
-                    <img src="/Images/Art/000refsheetsamfennec.png" >
+                    <img src="/Images/Art/gun.png" width="1106" height="1475" loading="lazy">
+                    <img src="/Images/Art/0000fenrefsheet.png" width="3000" height="2500" loading="lazy">
+                    <img src="/Images/Art/babbledog.png" width="1200" height="1600" loading="lazy">
+                    <img src="/Images/Art/gmmishark.webp" width="1333" height="2000" loading="lazy">
+                    <img src="/Images/Art/biggreedy.webp" width="1500" height="2000" loading="lazy">
+                    <img src="/Images/Art/glas.webp" width="1049" height="1311" loading="lazy">
+                    <img src="/Images/Art/000refsheetsamfennec.png" width="2250" height="3000" loading="lazy">
 
-                    <img src="/Images/Art/charcoal.webp" >
-                    <img src="/Images/Art/dogggie.webp" >
-                    <img src="/Images/Art/punk.webp" >
-                    <img src="/Images/Art/0refsheetsamfennec.webp" >
-                    <img src="/Images/Art/paste.webp" >
-                    <img src="/Images/Art/tori.webp" >
-                    <img src="/Images/Art/pain.webp" >
-                    <img src="/Images/Art/grapes.webp" >
-                    <img src="/Images/Art/cshr.webp" >
-                    <img src="/Images/Art/popsum.webp" >
-                    <img src="/Images/Art/fiort.webp" >
-                    <img src="/Images/Art/samrefv2.webp" >
-                    <img src="/Images/Art/glubbbb.webp" >
-                    <img src="/Images/Art/samref.webp" >
-                    <img src="/Images/Art/halo.webp" >
-                    <img src="/Images/Art/coffee.webp">
-                    <img src="/Images/Art/vicki.webp">
-                    <img src="/Images/Art/avali.webp">
-                    <img src="/Images/Art/00pascalrefsheet.webp">
-                    <img src="/Images/Art/glubcat.webp" >
-                    <img src="/Images/Art/halflifr.webp">
-                    <img src="/Images/Art/verick.webp">
-                    <img src="/Images/Art/00sierrarefsheet.webp">
-                    <img src="/Images/Art/butter.webp">
+                    <img src="/Images/Art/charcoal.webp" width="3302" height="3302" loading="lazy">
+                    <img src="/Images/Art/dogggie.webp" width="1300" height="1500" loading="lazy">
+                    <img src="/Images/Art/punk.webp" width="3000" height="3000" loading="lazy">
+                    <img src="/Images/Art/0refsheetsamfennec.webp" width="1750" height="2500" loading="lazy">
+                    <img src="/Images/Art/paste.webp" width="2650" height="2650" loading="lazy">
+                    <img src="/Images/Art/tori.webp" width="775" height="775" loading="lazy">
+                    <img src="/Images/Art/pain.webp" width="2560" height="3005" loading="lazy">
+                    <img src="/Images/Art/grapes.webp" width="3000" height="4000" loading="lazy">
+                    <img src="/Images/Art/cshr.webp" width="3792" height="2853" loading="lazy">
+                    <img src="/Images/Art/popsum.webp" width="1739" height="1739" loading="lazy">
+                    <img src="/Images/Art/fiort.webp" width="1200" height="1200" loading="lazy">
+                    <img src="/Images/Art/samrefv2.webp" width="2000" height="3000" loading="lazy">
+                    <img src="/Images/Art/glubbbb.webp" width="1500" height="2000" loading="lazy">
+                    <img src="/Images/Art/samref.webp" width="1837" height="2449" loading="lazy">
+                    <img src="/Images/Art/halo.webp" width="727" height="970" loading="lazy">
+                    <img src="/Images/Art/coffee.webp" width="1138" height="1517" loading="lazy">
+                    <img src="/Images/Art/vicki.webp" width="1318" height="1757" loading="lazy">
+                    <img src="/Images/Art/avali.webp" width="1402" height="1869" loading="lazy">
+                    <img src="/Images/Art/00pascalrefsheet.webp" width="1998" height="1997" loading="lazy">
+                    <img src="/Images/Art/glubcat.webp" width="1150" height="1150" loading="lazy">
+                    <img src="/Images/Art/halflifr.webp" width="1353" height="1804" loading="lazy">
+                    <img src="/Images/Art/verick.webp" width="1597" height="1997" loading="lazy">
+                    <img src="/Images/Art/00sierrarefsheet.webp" width="3000" height="4000" loading="lazy">
+                    <img src="/Images/Art/butter.webp" width="1685" height="1348" loading="lazy">
                 </div>
 
                 <div class="gallery-grid">


### PR DESCRIPTION
This attempts to add lazy loading for all the images on the art page via the loading attribute that modern browsers have. Also manually defines the image resolutions for all the images so the browser knows it before it even starts downloading the files which both helps the lazy loading work properly and also prevents stuff from jumping around randomly while loading which happens both with and without lazy loading.

~This pull request says "Attempt" because while I'm almost certain this works I wasn't _actually_ able to fully test out the lazy loading itself since I don't have any local setup for serving files to myself like a server would~
I just now tested in a different browser with dev tools that actually show me stuff locally and it all works 👍